### PR TITLE
Fix warning popup of dark Nord

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,9 @@
 {
   "name": "Nord theme",
-  "version": "0.0.4",
-  "authors": ["Sergei Metlenkin <s.metlenkin@gmail.com>"],
+  "version": "0.0.5",
+  "authors": [
+    "Sergei Metlenkin <s.metlenkin@gmail.com>"
+  ],
   "description": "Nord themes for Zed",
   "repository": "https://github.com/mikasius/zed-nord-theme"
 }

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -134,8 +134,8 @@
         "unreachable.background": null,
         "unreachable.border": null,
         "warning": "#ebcb8b",
-        "warning.background": null,
-        "warning.border": "#ebcb8b00",
+        "warning.background": "#2e3440",
+        "warning.border": "#ebcb8b",
         "players": [
           {
             "cursor": "#eceff4",


### PR DESCRIPTION
Suggested fix to change the following

![zed-current](https://github.com/mikasius/zed-nord-theme/assets/50987414/c0ea30f4-59a2-4bf7-8982-c2c2bf2411dc)

to

![zed-suggested](https://github.com/mikasius/zed-nord-theme/assets/50987414/a5b68509-bbc6-40bd-aef1-4a2514d30730)

to improve readability.

New `warning.background` is `surface.background`, the same that the Zed Dracula theme uses for this.