### PR TITLE
fix: cursor color

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -139,7 +139,7 @@
         "warning.border": "#ebcb8b",
         "players": [
           {
-            "cursor": "#434c5e99",
+            "cursor": "#eceff4",
             "background": "#434c5e99",
             "selection": "#434c5e99"
           },


### PR DESCRIPTION
fixes #14 
currently the cursor is not usable in dark mode, this updates the cursor color so that it is more visible:

For example:

![image](https://github.com/user-attachments/assets/706207bb-4d92-404c-a73d-be11ee472b54)

I kept the selection color as-is because it still looks good as you can see.

Something I am not sure about is the players array i.e. so if other parts of that need to change please let me know.
```
"players": [
```