### PR TITLE
Add property for dark mode

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -309,6 +309,11 @@
             "color": "#D8DEE9",
             "font_style": null,
             "font_weight": null
+          },
+          "property": {
+            "color": "#81A1C1",
+            "font_style": null,
+            "font_weight": null
           }
         }
       }


### PR DESCRIPTION
Adding property here means we colour a lot of extra parts of the ast, meaning we get less white parts.