### PR TITLE
Readability updates for light variant

### DIFF
--- a/themes/nord.json
+++ b/themes/nord.json
@@ -335,7 +335,7 @@
         "surface.background": "#f6f8fa",
         "background": "#eceff4",
 
-        "element.background": "#159739",
+        "element.background": "#e5e9f0",
         "element.hover": "#ebf0f4",
         "element.active": "#ebf0f4",
         "element.selected": "#e2e5e9",

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -465,7 +465,7 @@
         "players": [],
         "syntax": {
           "attribute": {
-            "color": "#D8DEE9",
+            "color": "#24292e",
             "font_style": null,
             "font_weight": null
           },

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -403,8 +403,8 @@
         "terminal.ansi.green": null,
         "terminal.ansi.bright_green": null,
         "terminal.ansi.dim_green": null,
-        "terminal.ansi.yellow": null,
-        "terminal.ansi.bright_yellow": null,
+        "terminal.ansi.yellow": "#bfa76b",
+        "terminal.ansi.bright_yellow": "#bfa76b",
         "terminal.ansi.dim_yellow": null,
         "terminal.ansi.blue": null,
         "terminal.ansi.bright_blue": null,
@@ -459,9 +459,9 @@
         "unreachable": null,
         "unreachable.background": null,
         "unreachable.border": null,
-        "warning": null,
+        "warning": "#bfa76b",
         "warning.background": null,
-        "warning.border": null,
+        "warning.border": "#bfa76b",
         "players": [],
         "syntax": {
           "attribute": {


### PR DESCRIPTION
## Label readability

Before:

<img width="747" height="77" alt="image" src="https://github.com/user-attachments/assets/67efbade-e0b5-4069-ae91-35db9a88502c" />

After:

<img width="727" height="85" alt="image" src="https://github.com/user-attachments/assets/d42f56fb-802c-443f-9b2f-11f8a64a1f25" />


## Warning readability

Before:

<img width="1665" height="141" alt="image" src="https://github.com/user-attachments/assets/c2b7feb5-8c40-4e58-9ce2-e4b40a66ccba" />

After:

<img width="1665" height="141" alt="image" src="https://github.com/user-attachments/assets/b84559ae-3197-4a27-84bd-dc343941df65" />


## Label background

Before:

<img width="1573" height="211" alt="image" src="https://github.com/user-attachments/assets/3c2279c1-7d34-4fcf-8df7-cf95104cd6ba" />

After:

<img width="1589" height="177" alt="image" src="https://github.com/user-attachments/assets/d0d6f88b-5575-404d-9969-14e958bcd213" />
